### PR TITLE
Fix RangeError with large volume of redirects

### DIFF
--- a/gatsby-plugin-s3/src/bin.ts
+++ b/gatsby-plugin-s3/src/bin.ts
@@ -290,8 +290,8 @@ export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) =
         });
 
         const base = config.protocol && config.hostname ? `${config.protocol}://${config.hostname}` : null;
-        uploadQueue.push(
-            ...redirectObjects.map(redirect =>
+        redirectObjects.forEach(redirect =>
+            uploadQueue.push(
                 asyncify(async () => {
                     const { fromPath, toPath: redirectPath } = redirect;
                     const redirectLocation = base ? resolveUrl(base, redirectPath) : redirectPath;


### PR DESCRIPTION
For sites that have a large number of redirects, the existing
implementation will throw a `RangeError: Maximum call stack size exceeded`
error, as all the redirect jobs are first built into memory, then spread
out into the uploadQueue. This change tweaks the flow to push the
redirect jobs into the queue using a forEach loop instead, which doesn't
trigger this same error with a large number of redirects.